### PR TITLE
Add .gitignore, updated urls.py to remove deprecated `patterns` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# Node
+node_modules/
+
+# webpack
+webpack-stats.json
+
+# sass/compass
+.sass-cache/
+
+# Compass/SASS
+.sass-cache
+
+

--- a/django_sb_admin/urls.py
+++ b/django_sb_admin/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import url
+import django_sb_admin.views
 
-urlpatterns = patterns('',
-    
-    url(r'^$', 'django_sb_admin.views.start', name='sb_admin_start'),
-    url(r'^dashboard/$', 'django_sb_admin.views.dashboard', name='sb_admin_dashboard'),
-    url(r'^charts/$', 'django_sb_admin.views.charts', name='sb_admin_charts'),
-    url(r'^tables/$', 'django_sb_admin.views.tables', name='sb_admin_tables'),
-    url(r'^forms/$', 'django_sb_admin.views.forms', name='sb_admin_forms'),
-    url(r'^bootstrap-elements/$', 'django_sb_admin.views.bootstrap_elements', name='sb_admin_bootstrap_elements'),
-    url(r'^bootstrap-grid/$', 'django_sb_admin.views.bootstrap_grid', name='sb_admin_bootstrap_grid'),
-    url(r'^rtl-dashboard/$', 'django_sb_admin.views.rtl_dashboard', name='sb_admin_rtl_dashboard'),
-    url(r'^blank/$', 'django_sb_admin.views.blank', name='sb_admin_blank'),
-)
+urlpatterns = [
+    url(r'^$', django_sb_admin.views.start, name='sb_admin_start'),
+    url(r'^dashboard/$', django_sb_admin.views.dashboard, name='sb_admin_dashboard'),
+    url(r'^charts/$', django_sb_admin.views.charts, name='sb_admin_charts'),
+    url(r'^tables/$', django_sb_admin.views.tables, name='sb_admin_tables'),
+    url(r'^forms/$', django_sb_admin.views.forms, name='sb_admin_forms'),
+    url(r'^bootstrap-elements/$', django_sb_admin.views.bootstrap_elements, name='sb_admin_bootstrap_elements'),
+    url(r'^bootstrap-grid/$', django_sb_admin.views.bootstrap_grid, name='sb_admin_bootstrap_grid'),
+    url(r'^rtl-dashboard/$', django_sb_admin.views.rtl_dashboard, name='sb_admin_rtl_dashboard'),
+    url(r'^blank/$', django_sb_admin.views.blank, name='sb_admin_blank'),
+]


### PR DESCRIPTION
Added .gitignore to filter out build products etc., removed django.conf.urls.patterns function (deprecated in 1.8, removed in 1.10), and fixed up the url references to be usable in 1.10.

Have not set up any testing, so I don't know whether this will still work in earlier versions of Django, but that's not my focus at this point.
